### PR TITLE
Fix conda create environment from file command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ It uses a process akin to a likelihood ratio test to attempt to discriminate bet
 
 Pydamage is not yet on *pypi* nor *conda*, but you can already install it using pip, provided that you have access to this repository.
 
-### Install dependancies in conda environment
+### Install dependencies in conda environment
 
 ```bash
 git clone git@github.com:maxibor/pydamage.git
 cd pydamage
-conda create -f environment.yml
+conda env create -f environment.yml
 conda activate pydamage
 ```
 


### PR DESCRIPTION
The conda command to install an environment from a YAML file needs to be `conda env create` instead of `conda create` in order to work.