### PR TITLE
Surpress writing row numbers to file

### DIFF
--- a/pydamage/utils.py
+++ b/pydamage/utils.py
@@ -153,7 +153,7 @@ def df_to_csv(
     df = df.round(3)
     if not outdir:
         outdir = "."
-    df.to_csv(f"{outdir}/{outfile}")
+    df.to_csv(f"{outdir}/{outfile}", index=False)
 
 
 def sort_dict_by_keys(adict: dict) -> dict:


### PR DESCRIPTION
When using the function `df_to_csv` to write the output of the filtered results, pandas create a separated column that includes the index names. However, this is not the case when using the same function on all results during the `analyze` command. This behaviour might be caused because during the filtering a query command explicitly adds row names and the function `to_csv` is called with the default parameter `index=True`.

This PR explicitly adds `index=False` to avoid having the row names saved to the text file for either commands.